### PR TITLE
Add f4 sanity checks; restrict final scan to WHG reference

### DIFF
--- a/scripts/F4_stats/1000g_ironage/README.md
+++ b/scripts/F4_stats/1000g_ironage/README.md
@@ -41,8 +41,24 @@ files and re-run `prep_data.sh`; every earlier (expensive) step stays cached.
 
 ```bash
 bash prep_data.sh                 # produces the eigenstrat files
-Rscript f4_HLA_analysis_v5.R      # runs from the directory holding them
+Rscript f4_sanity_checks.R        # positive/negative controls (run this first)
+Rscript f4_HLA_analysis_v5.R      # the WHG-reference scan
 ```
+
+`f4_common.R` holds the shared streaming reader + f4/jackknife machinery, so
+the sanity checks and the scan compute f4 identically. The final scan is
+restricted to the **WHG reference** (`REFERENCES = "WHG"`; override with
+`NERO_REFERENCES="WHG,Yamnaya,..."`).
+
+### Sanity checks (`f4_sanity_checks.R`)
+
+A panel of well-known admixture events with textbook expected directions,
+computed on chr1 with the same block jackknife, written to `sanity_checks.csv`:
+Steppe ancestry N>S Europe, CHG in Yamnaya, hunter-gatherer resurgence
+(Late>Early Neolithic), Anatolian-farmer ancestry in S Europe, African gene
+flow Iberia>Finland, plus a CEU-vs-GBR null. Each is reported PASS / CHECK
+against a `|z| > 3` threshold. A failing control means the f4 set-up is not
+reproducing a known result — investigate before trusting the HLA scan.
 
 The R step is configurable via environment variables (defaults reproduce the
 previous in-place behaviour):

--- a/scripts/F4_stats/1000g_ironage/f4_HLA_analysis_v5.R
+++ b/scripts/F4_stats/1000g_ironage/f4_HLA_analysis_v5.R
@@ -27,6 +27,13 @@
 #     alongside the raw and Bonferroni counts so "how many pairs are really
 #     significant" is reported directly.
 #
+# Changes from the first v5:
+#   - The streaming reader and f4 / f4-ratio machinery now live in f4_common.R,
+#     sourced here AND by f4_sanity_checks.R so the controls validate this exact
+#     code path. Run f4_sanity_checks.R first to confirm known admixture events.
+#   - Final analysis restricted to the WHG reference (REFERENCES = "WHG");
+#     override with the NERO_REFERENCES env var (comma-separated) if needed.
+#
 # Inherited from v4:
 #   - Outer loop over candidate ancient African source populations (region
 #     matches /Africa/i AND groupAge == "Ancient", n_samples >= MIN_SOURCE_N).
@@ -48,20 +55,17 @@
 
 suppressPackageStartupMessages(library(tidyverse))
 
-# ---- Run configuration (env-overridable; defaults reproduce v4 behaviour) ---
-DATADIR    <- Sys.getenv("NERO_DATADIR", ".")
-OUTDIR     <- Sys.getenv("NERO_OUTDIR",  ".")
-CHUNK_SNPS <- as.integer(Sys.getenv("NERO_CHUNK_SNPS", "50000"))
-if (is.na(CHUNK_SNPS) || CHUNK_SNPS < 1L) CHUNK_SNPS <- 50000L
-dir.create(OUTDIR, showWarnings = FALSE, recursive = TRUE)
+# Shared config + streaming reader + f4 / f4-ratio machinery (identical to the
+# code used by f4_sanity_checks.R, so the controls validate this exact path).
+SCRIPT_DIR <- tryCatch({
+    a <- commandArgs(FALSE)
+    f <- sub("^--file=", "", a[grep("^--file=", a)])
+    if (length(f)) dirname(normalizePath(f)) else getwd()
+}, error = function(e) getwd())
+source(file.path(SCRIPT_DIR, "f4_common.R"))
 
-out_path <- function(...) file.path(OUTDIR,  ...)
-in_path  <- function(...) file.path(DATADIR, ...)
-
-# ---- File prefixes / metadata path ------------------------------------------
-CHR6_PREFIX <- "6.1000g.sea.nocommas"
-CHR1_PREFIX <- "1.1000g.sea.nocommas"
-META_PATH   <- "sampleInfo_240504_impute_neosea_v07_240627_impute_iadk_cluster_map_ascii_250601_impute_sea_sampleId.tsv"
+# ---- Metadata path ----------------------------------------------------------
+META_PATH <- "sampleInfo_240504_impute_neosea_v07_240627_impute_iadk_cluster_map_ascii_250601_impute_sea_sampleId.tsv"
 
 # ---- Fixed populations ------------------------------------------------------
 OUTGROUP <- "Siberia_UpperPaleolithic_UstIshim"
@@ -71,217 +75,13 @@ SISTER   <- "YRI"
 # recipients of African admixture. We do NOT test ancient European
 # populations as targets in this run.
 TARGETS <- c("CEU", "GBR", "TSI", "IBS", "FIN")
-REFERENCES <- c("WHG", "EHG", "CHG",
-                "FarmerAnatolian", "FarmerEarly", "FarmerMiddle", "FarmerLate",
-                "Yamnaya")
-
-# ---- Region & block geometry (unchanged from v3) ----------------------------
-HLA_START <- 28000000
-HLA_END   <- 33000000
-BLOCK_CHR <- 5e6
-BLOCK_HLA <- 5e5
-BLOCK_WIN <- 5e4
-WIN_SIZE  <- 5e5
-WIN_STEP  <- 1e5
+# Final analysis: restricted to the WHG reference (the layer the HLA-source
+# signal tracks; see analysis notes). Override with NERO_REFERENCES if needed.
+REFERENCES <- strsplit(Sys.getenv("NERO_REFERENCES", "WHG"), ",")[[1]]
+REFERENCES <- trimws(REFERENCES[nzchar(trimws(REFERENCES))])
 
 # ---- Source-scan parameters -------------------------------------------------
 MIN_SOURCE_N <- 3   # min samples per candidate ancient African source pop
-
-# =============================================================================
-# Data loading: stream .geno -> per-population allele-frequency matrix
-# =============================================================================
-
-read_ind <- function(prefix) {
-    ind_alt  <- paste0(prefix, ".ind_")
-    ind_path <- if (file.exists(ind_alt)) ind_alt else paste0(prefix, ".ind")
-    read.table(ind_path, col.names = c("sample", "sex", "pop"),
-               stringsAsFactors = FALSE, fill = TRUE)
-}
-
-# Read the .ind and .snp tables, then stream the .geno file in chunks of
-# `chunk_snps` rows, parsing ONLY the columns that belong to `want_pops`, and
-# accumulate a per-SNP, per-population REF-allele frequency matrix. The full
-# sample-level genotype matrix is never held in memory.
-#
-# Frequency definition (identical to v4 pop_freq): for a population, the mean
-# over its samples of the REF-allele count (0/1/2; missing=9 -> NA), divided
-# by 2. SNPs where a population is entirely missing yield NA for that pop.
-read_eigenstrat_freq <- function(prefix, want_pops, chunk_snps = CHUNK_SNPS) {
-    cat(sprintf("  Reading: %s\n", basename(prefix)))
-
-    ind       <- read_ind(prefix)
-    n_samples <- nrow(ind)
-
-    # We only need chromosome + position downstream; skip the rest to save RAM.
-    snp <- read.table(paste0(prefix, ".snp"),
-                      colClasses = c("NULL", "character", "NULL",
-                                     "integer", "NULL", "NULL"))
-    names(snp) <- c("chr", "pos")
-    n_snp <- nrow(snp)
-
-    # Sample-column indices per requested population (present pops only).
-    pop_cols <- lapply(want_pops, function(p) which(ind$pop == p))
-    names(pop_cols) <- want_pops
-    present  <- want_pops[lengths(pop_cols) > 0]
-    if (length(present) == 0L)
-        stop("None of the requested populations are present in ", prefix)
-    pop_cols <- pop_cols[present]
-
-    # Union of needed sample columns; map each pop's columns into that subset.
-    needed         <- sort(unique(unlist(pop_cols, use.names = FALSE)))
-    pop_cols_local <- lapply(pop_cols, function(idx) match(idx, needed))
-
-    freq <- matrix(NA_real_, nrow = n_snp, ncol = length(present),
-                   dimnames = list(NULL, present))
-
-    con <- file(paste0(prefix, ".geno"), "rt")
-    on.exit(close(con))
-    row0 <- 0L
-    repeat {
-        lines <- readLines(con, n = chunk_snps)
-        if (length(lines) == 0L) break
-
-        if (row0 == 0L && length(utf8ToInt(lines[1])) != n_samples)
-            stop(sprintf(".geno width (%d) != n_samples in .ind (%d) for %s",
-                         length(utf8ToInt(lines[1])), n_samples, prefix))
-
-        # Parse only the needed columns. ASCII '0','1','2','9' -> 0,1,2,9.
-        m <- t(vapply(lines,
-                      function(l) utf8ToInt(l)[needed] - 48L,
-                      integer(length(needed)),
-                      USE.NAMES = FALSE))
-        m[m == 9L] <- NA_integer_
-
-        rng <- (row0 + 1L):(row0 + nrow(m))
-        for (p in present) {
-            sub <- m[, pop_cols_local[[p]], drop = FALSE]
-            freq[rng, p] <- rowMeans(sub, na.rm = TRUE) / 2
-        }
-        row0 <- row0 + nrow(m)
-    }
-    if (row0 != n_snp)
-        stop(sprintf(".geno rows (%d) != .snp rows (%d) for %s",
-                     row0, n_snp, prefix))
-
-    cat(sprintf("    %d SNPs, %d samples, %d pops total | loaded %d pops (%d samples)\n",
-                n_snp, n_samples, length(unique(ind$pop)),
-                length(present), length(needed)))
-
-    list(ind = ind, snp = snp, freq = freq, pops = present)
-}
-
-# =============================================================================
-# f4 machinery (frequency-matrix backed; arithmetic unchanged from v4)
-# =============================================================================
-
-apply_region_mask <- function(dat, start, end) {
-    mask <- rep(TRUE, nrow(dat$snp))
-    if (!is.null(start)) mask <- mask & (dat$snp$pos >= start)
-    if (!is.null(end))   mask <- mask & (dat$snp$pos <= end)
-    list(snp = dat$snp[mask, , drop = FALSE],
-         freq = dat$freq[mask, , drop = FALSE])
-}
-
-have_pops <- function(dat, pops) all(pops %in% colnames(dat$freq))
-
-compute_f4 <- function(dat, A, B, C, D,
-                       start = NULL, end = NULL, block_size = BLOCK_CHR) {
-    na_res <- list(f4=NA, se=NA, z=NA, p=NA, n_snps=0, n_blocks=0)
-    if (!have_pops(dat, c(A, B, C, D))) return(na_res)
-    sub <- apply_region_mask(dat, start, end)
-    if (nrow(sub$snp) < 10) return(na_res)
-
-    f4_snp <- (sub$freq[, A] - sub$freq[, B]) * (sub$freq[, C] - sub$freq[, D])
-    valid  <- !is.na(f4_snp)
-    f4_snp <- f4_snp[valid]
-    pos_v  <- sub$snp$pos[valid]
-    n <- length(f4_snp)
-    if (n < 10) return(list(f4=NA, se=NA, z=NA, p=NA, n_snps=n, n_blocks=0))
-
-    f4_est    <- mean(f4_snp)
-    blocks    <- floor(pos_v / block_size)
-    block_ids <- unique(blocks)
-    n_blocks  <- length(block_ids)
-    if (n_blocks < 2)
-        return(list(f4=f4_est, se=NA, z=NA, p=NA,
-                    n_snps=n, n_blocks=n_blocks))
-
-    f4_jk  <- sapply(block_ids, function(b) mean(f4_snp[blocks != b]))
-    pseudo <- n_blocks * f4_est - (n_blocks - 1) * f4_jk
-    se <- sqrt(var(pseudo) / n_blocks)
-    z  <- f4_est / se
-    list(f4=f4_est, se=se, z=z, p=2*pnorm(-abs(z)),
-         n_snps=n, n_blocks=n_blocks)
-}
-
-# alpha = f4(sister, outgroup; target, reference) /
-#         f4(sister, outgroup; source, reference)
-compute_f4_ratio <- function(dat, sister, outgroup, target, source, reference,
-                             start = NULL, end = NULL, block_size = BLOCK_CHR) {
-    na_res <- list(alpha=NA, se_alpha=NA, z_alpha=NA, p_alpha=NA,
-                   f4_num=NA, f4_den=NA, n_snps=0, n_blocks=0)
-    if (!have_pops(dat, c(sister, outgroup, target, source, reference)))
-        return(na_res)
-    sub <- apply_region_mask(dat, start, end)
-    if (nrow(sub$snp) < 10) return(na_res)
-
-    pA <- sub$freq[, sister]
-    pO <- sub$freq[, outgroup]
-    pX <- sub$freq[, target]
-    pB <- sub$freq[, source]
-    pC <- sub$freq[, reference]
-
-    num_snp <- (pA - pO) * (pX - pC)
-    den_snp <- (pA - pO) * (pB - pC)
-
-    valid <- !is.na(num_snp) & !is.na(den_snp)
-    num_snp <- num_snp[valid]; den_snp <- den_snp[valid]
-    pos_v <- sub$snp$pos[valid]
-    n <- length(num_snp)
-    if (n < 10) { na_res$n_snps <- n; return(na_res) }
-
-    num_est <- mean(num_snp); den_est <- mean(den_snp)
-    if (abs(den_est) < 1e-10) return(na_res)
-    alpha_est <- num_est / den_est
-
-    blocks    <- floor(pos_v / block_size)
-    block_ids <- unique(blocks)
-    n_blocks  <- length(block_ids)
-    if (n_blocks < 2)
-        return(list(alpha=alpha_est, se_alpha=NA, z_alpha=NA, p_alpha=NA,
-                    f4_num=num_est, f4_den=den_est,
-                    n_snps=n, n_blocks=n_blocks))
-
-    alpha_jk <- sapply(block_ids, function(b) {
-        keep  <- blocks != b
-        m_num <- mean(num_snp[keep])
-        m_den <- mean(den_snp[keep])
-        if (abs(m_den) < 1e-10) NA_real_ else m_num / m_den
-    })
-    alpha_jk <- alpha_jk[!is.na(alpha_jk)]
-    n_eff <- length(alpha_jk)
-    if (n_eff < 2)
-        return(list(alpha=alpha_est, se_alpha=NA, z_alpha=NA, p_alpha=NA,
-                    f4_num=num_est, f4_den=den_est,
-                    n_snps=n, n_blocks=n_blocks))
-
-    pseudo   <- n_eff * alpha_est - (n_eff - 1) * alpha_jk
-    se_alpha <- sqrt(var(pseudo) / n_eff)
-    z_alpha  <- alpha_est / se_alpha
-    list(alpha=alpha_est, se_alpha=se_alpha, z_alpha=z_alpha,
-         p_alpha=2*pnorm(-abs(z_alpha)),
-         f4_num=num_est, f4_den=den_est,
-         n_snps=n, n_blocks=n_blocks)
-}
-
-safe_diff <- function(a, b) {
-    if (is.na(a$f4) || is.na(b$f4) || is.na(a$se) || is.na(b$se))
-        return(c(diff=NA, se=NA, z=NA, p=NA))
-    d  <- a$f4 - b$f4
-    sd <- sqrt(a$se^2 + b$se^2)
-    z  <- d / sd
-    c(diff=d, se=sd, z=z, p=2*pnorm(-abs(z)))
-}
 
 test_f4_hla_vs_control <- function(dat6, dat1, A, B, C, D) {
     f4_hla  <- compute_f4(dat6, A, B, C, D,

--- a/scripts/F4_stats/1000g_ironage/f4_common.R
+++ b/scripts/F4_stats/1000g_ironage/f4_common.R
@@ -1,0 +1,226 @@
+#!/usr/bin/env Rscript
+# =============================================================================
+# f4_common.R
+# Shared configuration + data loading + f4 / f4-ratio machinery for the HLA
+# African-admixture analysis. Sourced by both:
+#   - f4_HLA_analysis_v5.R   (the scan)
+#   - f4_sanity_checks.R     (well-known-admixture positive controls)
+# so both compute f4 in byte-identical fashion (same streaming frequency
+# reader, same block jackknife).
+#
+# Pure base R (no tidyverse), so it is cheap to source from a diagnostic run.
+# See README.md for the memory model and the f4 sign convention.
+# =============================================================================
+
+# ---- Run configuration (env-overridable; defaults reproduce v4 behaviour) ---
+DATADIR    <- Sys.getenv("NERO_DATADIR", ".")
+OUTDIR     <- Sys.getenv("NERO_OUTDIR",  ".")
+CHUNK_SNPS <- as.integer(Sys.getenv("NERO_CHUNK_SNPS", "50000"))
+if (is.na(CHUNK_SNPS) || CHUNK_SNPS < 1L) CHUNK_SNPS <- 50000L
+dir.create(OUTDIR, showWarnings = FALSE, recursive = TRUE)
+
+out_path <- function(...) file.path(OUTDIR,  ...)
+in_path  <- function(...) file.path(DATADIR, ...)
+
+# ---- File prefixes ----------------------------------------------------------
+CHR6_PREFIX <- "6.1000g.sea.nocommas"
+CHR1_PREFIX <- "1.1000g.sea.nocommas"
+
+# ---- Region & block geometry ------------------------------------------------
+HLA_START <- 28000000
+HLA_END   <- 33000000
+BLOCK_CHR <- 5e6
+BLOCK_HLA <- 5e5
+BLOCK_WIN <- 5e4
+WIN_SIZE  <- 5e5
+WIN_STEP  <- 1e5
+
+# =============================================================================
+# Data loading: stream .geno -> per-population allele-frequency matrix
+# =============================================================================
+
+read_ind <- function(prefix) {
+    ind_alt  <- paste0(prefix, ".ind_")
+    ind_path <- if (file.exists(ind_alt)) ind_alt else paste0(prefix, ".ind")
+    read.table(ind_path, col.names = c("sample", "sex", "pop"),
+               stringsAsFactors = FALSE, fill = TRUE)
+}
+
+# Read .ind + .snp, then stream .geno in chunks of `chunk_snps` rows, parsing
+# ONLY the columns belonging to `want_pops`, and accumulate a per-SNP,
+# per-population REF-allele frequency matrix. The full sample-level genotype
+# matrix is never materialised. (Verified identical to a dense-matrix read.)
+read_eigenstrat_freq <- function(prefix, want_pops, chunk_snps = CHUNK_SNPS) {
+    cat(sprintf("  Reading: %s\n", basename(prefix)))
+
+    ind       <- read_ind(prefix)
+    n_samples <- nrow(ind)
+
+    snp <- read.table(paste0(prefix, ".snp"),
+                      colClasses = c("NULL", "character", "NULL",
+                                     "integer", "NULL", "NULL"))
+    names(snp) <- c("chr", "pos")
+    n_snp <- nrow(snp)
+
+    pop_cols <- lapply(want_pops, function(p) which(ind$pop == p))
+    names(pop_cols) <- want_pops
+    present  <- want_pops[lengths(pop_cols) > 0]
+    if (length(present) == 0L)
+        stop("None of the requested populations are present in ", prefix)
+    pop_cols <- pop_cols[present]
+
+    needed         <- sort(unique(unlist(pop_cols, use.names = FALSE)))
+    pop_cols_local <- lapply(pop_cols, function(idx) match(idx, needed))
+
+    freq <- matrix(NA_real_, nrow = n_snp, ncol = length(present),
+                   dimnames = list(NULL, present))
+
+    con <- file(paste0(prefix, ".geno"), "rt")
+    on.exit(close(con))
+    row0 <- 0L
+    repeat {
+        lines <- readLines(con, n = chunk_snps)
+        if (length(lines) == 0L) break
+
+        if (row0 == 0L && length(utf8ToInt(lines[1])) != n_samples)
+            stop(sprintf(".geno width (%d) != n_samples in .ind (%d) for %s",
+                         length(utf8ToInt(lines[1])), n_samples, prefix))
+
+        m <- t(vapply(lines,
+                      function(l) utf8ToInt(l)[needed] - 48L,
+                      integer(length(needed)),
+                      USE.NAMES = FALSE))
+        m[m == 9L] <- NA_integer_
+
+        rng <- (row0 + 1L):(row0 + nrow(m))
+        for (p in present) {
+            sub <- m[, pop_cols_local[[p]], drop = FALSE]
+            freq[rng, p] <- rowMeans(sub, na.rm = TRUE) / 2
+        }
+        row0 <- row0 + nrow(m)
+    }
+    if (row0 != n_snp)
+        stop(sprintf(".geno rows (%d) != .snp rows (%d) for %s",
+                     row0, n_snp, prefix))
+
+    cat(sprintf("    %d SNPs, %d samples, %d pops total | loaded %d pops (%d samples)\n",
+                n_snp, n_samples, length(unique(ind$pop)),
+                length(present), length(needed)))
+
+    list(ind = ind, snp = snp, freq = freq, pops = present)
+}
+
+# =============================================================================
+# f4 machinery (frequency-matrix backed)
+# =============================================================================
+
+apply_region_mask <- function(dat, start, end) {
+    mask <- rep(TRUE, nrow(dat$snp))
+    if (!is.null(start)) mask <- mask & (dat$snp$pos >= start)
+    if (!is.null(end))   mask <- mask & (dat$snp$pos <= end)
+    list(snp = dat$snp[mask, , drop = FALSE],
+         freq = dat$freq[mask, , drop = FALSE])
+}
+
+have_pops <- function(dat, pops) all(pops %in% colnames(dat$freq))
+
+# f4(A, B; C, D) = mean_SNP (pA - pB)(pC - pD), block (leave-one-out) jackknife
+# SE over physical-position blocks of `block_size`.
+compute_f4 <- function(dat, A, B, C, D,
+                       start = NULL, end = NULL, block_size = BLOCK_CHR) {
+    na_res <- list(f4=NA, se=NA, z=NA, p=NA, n_snps=0, n_blocks=0)
+    if (!have_pops(dat, c(A, B, C, D))) return(na_res)
+    sub <- apply_region_mask(dat, start, end)
+    if (nrow(sub$snp) < 10) return(na_res)
+
+    f4_snp <- (sub$freq[, A] - sub$freq[, B]) * (sub$freq[, C] - sub$freq[, D])
+    valid  <- !is.na(f4_snp)
+    f4_snp <- f4_snp[valid]
+    pos_v  <- sub$snp$pos[valid]
+    n <- length(f4_snp)
+    if (n < 10) return(list(f4=NA, se=NA, z=NA, p=NA, n_snps=n, n_blocks=0))
+
+    f4_est    <- mean(f4_snp)
+    blocks    <- floor(pos_v / block_size)
+    block_ids <- unique(blocks)
+    n_blocks  <- length(block_ids)
+    if (n_blocks < 2)
+        return(list(f4=f4_est, se=NA, z=NA, p=NA,
+                    n_snps=n, n_blocks=n_blocks))
+
+    f4_jk  <- sapply(block_ids, function(b) mean(f4_snp[blocks != b]))
+    pseudo <- n_blocks * f4_est - (n_blocks - 1) * f4_jk
+    se <- sqrt(var(pseudo) / n_blocks)
+    z  <- f4_est / se
+    list(f4=f4_est, se=se, z=z, p=2*pnorm(-abs(z)),
+         n_snps=n, n_blocks=n_blocks)
+}
+
+# alpha = f4(sister, outgroup; target, reference) /
+#         f4(sister, outgroup; source, reference)
+compute_f4_ratio <- function(dat, sister, outgroup, target, source, reference,
+                             start = NULL, end = NULL, block_size = BLOCK_CHR) {
+    na_res <- list(alpha=NA, se_alpha=NA, z_alpha=NA, p_alpha=NA,
+                   f4_num=NA, f4_den=NA, n_snps=0, n_blocks=0)
+    if (!have_pops(dat, c(sister, outgroup, target, source, reference)))
+        return(na_res)
+    sub <- apply_region_mask(dat, start, end)
+    if (nrow(sub$snp) < 10) return(na_res)
+
+    pA <- sub$freq[, sister]
+    pO <- sub$freq[, outgroup]
+    pX <- sub$freq[, target]
+    pB <- sub$freq[, source]
+    pC <- sub$freq[, reference]
+
+    num_snp <- (pA - pO) * (pX - pC)
+    den_snp <- (pA - pO) * (pB - pC)
+
+    valid <- !is.na(num_snp) & !is.na(den_snp)
+    num_snp <- num_snp[valid]; den_snp <- den_snp[valid]
+    pos_v <- sub$snp$pos[valid]
+    n <- length(num_snp)
+    if (n < 10) { na_res$n_snps <- n; return(na_res) }
+
+    num_est <- mean(num_snp); den_est <- mean(den_snp)
+    if (abs(den_est) < 1e-10) return(na_res)
+    alpha_est <- num_est / den_est
+
+    blocks    <- floor(pos_v / block_size)
+    block_ids <- unique(blocks)
+    n_blocks  <- length(block_ids)
+    if (n_blocks < 2)
+        return(list(alpha=alpha_est, se_alpha=NA, z_alpha=NA, p_alpha=NA,
+                    f4_num=num_est, f4_den=den_est,
+                    n_snps=n, n_blocks=n_blocks))
+
+    alpha_jk <- sapply(block_ids, function(b) {
+        keep  <- blocks != b
+        m_num <- mean(num_snp[keep])
+        m_den <- mean(den_snp[keep])
+        if (abs(m_den) < 1e-10) NA_real_ else m_num / m_den
+    })
+    alpha_jk <- alpha_jk[!is.na(alpha_jk)]
+    n_eff <- length(alpha_jk)
+    if (n_eff < 2)
+        return(list(alpha=alpha_est, se_alpha=NA, z_alpha=NA, p_alpha=NA,
+                    f4_num=num_est, f4_den=den_est,
+                    n_snps=n, n_blocks=n_blocks))
+
+    pseudo   <- n_eff * alpha_est - (n_eff - 1) * alpha_jk
+    se_alpha <- sqrt(var(pseudo) / n_eff)
+    z_alpha  <- alpha_est / se_alpha
+    list(alpha=alpha_est, se_alpha=se_alpha, z_alpha=z_alpha,
+         p_alpha=2*pnorm(-abs(z_alpha)),
+         f4_num=num_est, f4_den=den_est,
+         n_snps=n, n_blocks=n_blocks)
+}
+
+safe_diff <- function(a, b) {
+    if (is.na(a$f4) || is.na(b$f4) || is.na(a$se) || is.na(b$se))
+        return(c(diff=NA, se=NA, z=NA, p=NA))
+    d  <- a$f4 - b$f4
+    sd <- sqrt(a$se^2 + b$se^2)
+    z  <- d / sd
+    c(diff=d, se=sd, z=z, p=2*pnorm(-abs(z)))
+}

--- a/scripts/F4_stats/1000g_ironage/f4_sanity_checks.R
+++ b/scripts/F4_stats/1000g_ironage/f4_sanity_checks.R
@@ -1,0 +1,117 @@
+#!/usr/bin/env Rscript
+# =============================================================================
+# f4_sanity_checks.R
+# Positive/negative controls for the f4 set-up: a panel of WELL-KNOWN admixture
+# events with textbook expected directions, computed with the SAME machinery as
+# the HLA scan (f4_common.R: same streaming reader, same block jackknife).
+#
+# If the pipeline is working, the positive controls recover the expected sign
+# with large |z|, and the null control stays near zero. In particular the
+# Africa-into-Southern-Europe control validates exactly the kind of signal the
+# HLA analysis is built to detect.
+#
+# Convention used here (intuitive form):
+#     f4(Donor, Outgroup; Test, Control)
+#   is POSITIVE when `Test` shares more drift with `Donor` than `Control` does
+#   (i.e. Test has more Donor-related ancestry). This is the same compute_f4()
+#   used by the scan, just with arguments ordered for readability.
+#
+# Computed genome-wide on chr1 (the analysis baseline), 5 Mb jackknife blocks.
+# Output: sanity_checks.csv + a PASS/FAIL table to stderr.
+# =============================================================================
+
+SCRIPT_DIR <- tryCatch({
+    a <- commandArgs(FALSE)
+    f <- sub("^--file=", "", a[grep("^--file=", a)])
+    if (length(f)) dirname(normalizePath(f)) else getwd()
+}, error = function(e) getwd())
+source(file.path(SCRIPT_DIR, "f4_common.R"))
+
+OUTGROUP <- "Siberia_UpperPaleolithic_UstIshim"
+
+# ---- Control panel ----------------------------------------------------------
+# expect: "+" positive control (Test > Control in Donor ancestry),
+#         "0" null control (no differential ancestry, |z| should stay small).
+panel <- rbind.data.frame(
+  c("Steppe ancestry higher in N than S Europe (FIN>TSI)",
+    "Yamnaya", "FIN", "TSI", "+"),
+  c("Steppe ancestry higher in N than S Europe (CEU>IBS)",
+    "Yamnaya", "CEU", "IBS", "+"),
+  c("CHG ancestry in Yamnaya (Yamnaya = EHG + CHG)",
+    "CHG", "Yamnaya", "EHG", "+"),
+  c("Hunter-gatherer resurgence in Late vs Early Neolithic",
+    "WHG", "FarmerLate", "FarmerEarly", "+"),
+  c("Anatolian-farmer ancestry in S Europe vs hunter-gatherers",
+    "FarmerAnatolian", "TSI", "WHG", "+"),
+  c("African gene flow higher in Iberia than Finland (S>N)",
+    "YRI", "IBS", "FIN", "+"),
+  c("NULL control: CEU vs GBR have ~equal Steppe ancestry",
+    "Yamnaya", "CEU", "GBR", "0"),
+  stringsAsFactors = FALSE)
+names(panel) <- c("test", "donor", "test_pop", "control", "expect")
+
+Z_THRESH <- 3   # |z| considered a clear signal
+
+cat(strrep("=", 78), "\n", sep="")
+cat("f4 SANITY CHECKS — well-known admixture events (chr1, genome-wide)\n")
+cat("  f4(Donor, Outgroup; Test, Control) > 0  <=>  Test more Donor-like than Control\n")
+cat(strrep("=", 78), "\n\n", sep="")
+
+want_pops <- unique(c(OUTGROUP,
+                      panel$donor, panel$test_pop, panel$control))
+
+cat("Loading chr1 (frequency-only, controls' populations)...\n")
+dat1 <- read_eigenstrat_freq(in_path(CHR1_PREFIX), want_pops)
+
+missing <- setdiff(want_pops, dat1$pops)
+if (length(missing))
+    cat(sprintf("\nWARNING: populations absent from chr1 (their tests will be NA): %s\n",
+                paste(missing, collapse=", ")))
+
+# ---- Run the panel ----------------------------------------------------------
+res <- vector("list", nrow(panel))
+for (i in seq_len(nrow(panel))) {
+    p <- panel[i, ]
+    r <- tryCatch(
+        compute_f4(dat1, p$donor, OUTGROUP, p$test_pop, p$control,
+                   block_size = BLOCK_CHR),
+        error = function(e) list(f4=NA, se=NA, z=NA, p=NA, n_snps=0))
+    pass <- if (is.na(r$z)) NA
+            else if (p$expect == "+") (r$z >  Z_THRESH)
+            else                      (abs(r$z) < Z_THRESH)   # null control
+    res[[i]] <- data.frame(
+        test       = p$test,
+        f4_formula = sprintf("f4(%s, O; %s, %s)", p$donor, p$test_pop, p$control),
+        expect     = p$expect,
+        f4         = r$f4, se = r$se, z = r$z, p = r$p,
+        n_snps     = r$n_snps,
+        pass       = pass,
+        stringsAsFactors = FALSE)
+}
+res <- do.call(rbind, res)
+
+write.csv(res, out_path("sanity_checks.csv"), row.names = FALSE)
+
+# ---- Report -----------------------------------------------------------------
+cat("\n")
+cat(sprintf("  %-55s %4s %10s %8s %9s  %s\n",
+            "control", "exp", "f4", "z", "p", "result"))
+cat("  ", strrep("-", 95), "\n", sep="")
+for (i in seq_len(nrow(res))) {
+    r <- res[i, ]
+    verdict <- if (is.na(r$pass)) "NA (missing pop)"
+               else if (r$pass)   "PASS"
+               else               "*** CHECK ***"
+    cat(sprintf("  %-55s %4s %10.5f %8.2f %9.1e  %s\n",
+                substr(r$test, 1, 55), r$expect,
+                r$f4, r$z, r$p, verdict))
+}
+np  <- sum(res$pass, na.rm = TRUE)
+nt  <- sum(!is.na(res$pass))
+cat(sprintf("\n  %d / %d controls behaved as expected (|z| threshold = %g).\n",
+            np, nt, Z_THRESH))
+cat("  Saved: ", out_path("sanity_checks.csv"), "\n", sep="")
+if (nt > 0 && np < nt)
+    cat("  NOTE: a failing control means the f4 set-up is NOT reproducing a\n",
+        "        textbook result -- investigate before trusting the HLA scan.\n", sep="")
+cat("\nDone.\n")

--- a/scripts/F4_stats/1000g_ironage/prep_data.sh
+++ b/scripts/F4_stats/1000g_ironage/prep_data.sh
@@ -122,4 +122,5 @@ done
 echo
 echo "All chromosomes processed. To re-run any step, delete its output file"
 echo "or invoke with FORCE=1 (e.g. 'FORCE=1 bash prep_data.sh')."
-echo "Run f4_HLA_analysis_v5.R next (memory-bounded; v4 retained for provenance)."
+echo "Next: Rscript f4_sanity_checks.R   (confirm known admixture events)"
+echo "then: Rscript f4_HLA_analysis_v5.R (the WHG-reference scan)."


### PR DESCRIPTION
Factor the streaming reader + f4/jackknife machinery into f4_common.R, sourced by both the scan and a new f4_sanity_checks.R, so the controls validate the exact code path used by the analysis.

f4_sanity_checks.R runs a panel of well-known admixture events on chr1 with the same block jackknife and expected directions:
  - Steppe ancestry higher in N than S Europe (Yamnaya; FIN>TSI, CEU>IBS)
  - CHG ancestry in Yamnaya (CHG; Yamnaya>EHG)
  - hunter-gatherer resurgence (WHG; FarmerLate>FarmerEarly)
  - Anatolian-farmer ancestry in S Europe (FarmerAnatolian; TSI>WHG)
  - African gene flow Iberia>Finland (YRI; IBS>FIN) -- validates the African direction the HLA scan depends on
  - NULL control: CEU vs GBR (~equal Steppe) Each reported PASS/CHECK vs a |z|>3 threshold; results in sanity_checks.csv.

f4_HLA_analysis_v5.R now sources f4_common.R and restricts REFERENCES to "WHG" (override via NERO_REFERENCES). Verified: common-module reader matches a dense read and compute_f4 matches a hand calc; all three scripts parse.

https://claude.ai/code/session_01Xv1gj3zBAja96LL9o4nKvj