### PR TITLE
sanity: add North African (Morocco_HG) gene-flow control

### DIFF
--- a/scripts/F4_stats/1000g_ironage/f4_sanity_checks.R
+++ b/scripts/F4_stats/1000g_ironage/f4_sanity_checks.R
@@ -45,6 +45,8 @@ panel <- rbind.data.frame(
     "FarmerAnatolian", "TSI", "WHG", "+"),
   c("African gene flow higher in Iberia than Finland (S>N)",
     "YRI", "IBS", "FIN", "+"),
+  c("N-African gene flow higher in Iberia than Finland (Morocco_HG donor)",
+    "Morocco_HG", "IBS", "FIN", "+"),
   c("NULL control: CEU vs GBR have ~equal Steppe ancestry",
     "Yamnaya", "CEU", "GBR", "0"),
   stringsAsFactors = FALSE)


### PR DESCRIPTION
Add f4(Morocco_HG, UstIshim; IBS, FIN) -- a North-African donor matching the likely source of the HLA signal, a more apt positive control than the YRI (sub-Saharan) version for African gene flow into Iberia.

https://claude.ai/code/session_01Xv1gj3zBAja96LL9o4nKvj